### PR TITLE
Update dot language link

### DIFF
--- a/r/R/dagitty.r
+++ b/r/R/dagitty.r
@@ -1464,7 +1464,7 @@ toString.dagitty <- function( x, format="dagitty", ... ){
 #' variable (see \code{\link{graphLayout}}) 
 #' @details
 #' The textual syntax for DAGitty graph is based on the dot language of the 
-#' graphviz software (\url{http://www.graphviz.org/content/dot-language}). This is a
+#' graphviz software (\url{https://graphviz.gitlab.io/_pages/doc/info/lang.html}). This is a
 #' fairly intuitive syntax -- use the examples below and in the other functions to
 #' get you started. An important difference to graphviz is that the DAGitty language
 #' supports several types of graphs, which have different semantics. However, many users


### PR DESCRIPTION
The URL for the dot language link has changed to https://graphviz.gitlab.io/_pages/doc/info/lang.html