### PR TITLE
Read a DAG from a URL parameter

### DIFF
--- a/gui/dags.html
+++ b/gui/dags.html
@@ -130,6 +130,9 @@ alert("DAGitty requires Internet Explorer 9 or higher.\n"+
 				DAGittyControl.getView().closeDialog()
 			}
 		}
+		
+		// Attempt to load DAG from the URL parameter "adjmatrix"
+		loadDagFromUrlParameter();
 	}
 	
 	window.onload = initialize;

--- a/gui/js/main.js
+++ b/gui/js/main.js
@@ -429,6 +429,27 @@ function loadDAGFromTextData(){
 	document.getElementById("adj_matrix").style.backgroundColor="#fff";
 }
 
+// Read a Dag from a URL parameter
+// e.g. http://www.dagitty.net/dags.html?adjmatrix=B%201%20@1.400,-1.460%0AD%20O%20@1.400,1.621%0A%0AB%20D
+function loadDagFromUrlParameter(){
+	var adjMatrixFromUrlParameter = getUrlParameter("adjmatrix");
+	if((adjMatrixFromUrlParameter!==undefined) && (adjMatrixFromUrlParameter!='')){
+		document.getElementById("adj_matrix").value = adjMatrixFromUrlParameter;
+		loadDAGFromTextData();
+	}
+}
+
+function getUrlParameter(sParam) {
+    var sPageURL = decodeURIComponent(window.location.search.substring(1));
+    var sURLVariables = sPageURL.split('&');
+    for (var i = 0; i < sURLVariables.length; i++) {
+        var sParameterName = sURLVariables[i].split('=');
+        if (sParameterName[0] === sParam) {
+            return sParameterName[1] === undefined ? true : sParameterName[1];
+        }
+    }
+};
+
 function generateSpringLayout(){
 	var layouter = new GraphLayouter.Spring( Model.dag );
 	_.each(Model.dag.edges,function(e){delete e["layout_pos_x"];delete e["layout_pos_y"]})


### PR DESCRIPTION
I'm developing a database of causal hypotheses. I'd like the user to be able to export some of the DAGs in my database into dagitty.  I couldn't find an easy way to import a file, without creating a DAG on your server first.  If there's already a way to do this, that's great!  If not, I've suggested adding some code to allow a user to pass data from a URL parameter into the `adj_matrix` text box, then reload the DAG.  This will allow me to add a link on my website for the user to open the DAG in dagitty, e.g.:

[http://www.dagitty.net/dags.html?adjmatrix=B%201%20@1.400,-1.460%0AD%20O%20@1.400,1.621%0A%0AB%20D](http://www.dagitty.net/dags.html?adjmatrix=B%201%20@1.400,-1.460%0AD%20O%20@1.400,1.621%0A%0AB%20D)

I'm not a security expert, so if this is a bad idea because it will allow arbitrary injection, please ignore this suggestion.

I've tested the addition to main.js, and it seems to work.  I guessed where the call should go in the dags.html, but have not tested this.  Note that the function `loadDagFromUrlParameter()` does nothing if it doesn't find a URL parameter named `adjmatrix`.