### PR TITLE
Allow nodes to be relabelled with plotmath expressions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.swp
 
+.Rproj.user

--- a/r/R/dagitty.r
+++ b/r/R/dagitty.r
@@ -1075,7 +1075,13 @@ graphLayout <- function( x, method="spring" ){
 #' @param abbreviate.names logical. Whether to abbreviate variable names.
 #' @param show.coefficients logical. Whether to plot coefficients defined in the graph syntax
 #'  on the edges.
+#' @param nodenames If not NULL, a named vector or expression list 
+#'  to rename the nodes.  
 #' @param ... not used.
+#' 
+#' @details If \code{nodenames} is not \code{NULL}, it should be a 
+#'  named vector of characters or expressions to use to rename (some of) 
+#'  the nodes, e.g. node \code{"X"} could be renamed using \code{expression(X = alpha^2)}.
 #'
 #' @export
 plot.dagitty <- function( x,
@@ -1116,8 +1122,10 @@ plot.dagitty <- function( x,
 	ylim <- c(-max(coords$y+wy/2),-min(coords$y-wy/2))
 	plot( NA, xlim=xlim, ylim=ylim, xlab="", ylab="", bty="n",
 		xaxt="n", yaxt="n" )
-	wx <- strwidth("xx") + sapply( labels, strwidth )
-	wy <- strheight("\n") + sapply( labels, strheight )
+	wx <- sapply( labels, strwidth ) + strwidth("xx") 
+	names(wx) <- names(coords$x)
+	wy <- sapply( labels, strheight ) + strheight("\n")
+	names(wy) <- names(coords$x)
 	asp <- par("pin")[1]/diff(par("usr")[1:2]) /
 		(par("pin")[2]/diff(par("usr")[3:4]))
 	ex <- edges(x)

--- a/r/R/dagitty.r
+++ b/r/R/dagitty.r
@@ -1081,6 +1081,7 @@ graphLayout <- function( x, method="spring" ){
 plot.dagitty <- function( x,
 	abbreviate.names=FALSE, 
 	show.coefficients=FALSE,
+	nodenames=NULL,
 	... ){	
 	x <- as.dagitty( x )
 	.supportsTypes(x,c("dag","mag","pdag"))
@@ -1095,13 +1096,17 @@ plot.dagitty <- function( x,
 	} else {
 		labels <- names(coords$x)
 	}
+	if(!is.null(nodenames)){
+	  names(labels) <- names(coords$x)
+	  labels[names(nodenames)] <- nodenames
+	}
 	omar <- par("mar")
 	par(mar=rep(0,4))
 	plot.new()
 	par(new=TRUE)
-	wx <- sapply( paste0("mm",labels), 
+	wx <- strwidth("mm",units="inches") + sapply( labels, 
 		function(s) strwidth(s,units="inches") )
-	wy <- sapply( paste0("\n",labels), 
+	wy <- strheight("\n") + sapply( labels, 
 		function(s) strheight(s,units="inches") )
 	ppi.x <- dev.size("in")[1] / (max(coords$x)-min(coords$x))
 	ppi.y <- dev.size("in")[2] / (max(coords$y)-min(coords$y))
@@ -1111,10 +1116,8 @@ plot.dagitty <- function( x,
 	ylim <- c(-max(coords$y+wy/2),-min(coords$y-wy/2))
 	plot( NA, xlim=xlim, ylim=ylim, xlab="", ylab="", bty="n",
 		xaxt="n", yaxt="n" )
-	wx <- sapply( labels, 
-		function(s) strwidth(paste0("xx",s)) )
-	wy <- sapply( labels,
-		function(s) strheight(paste0("\n",s)) )
+	wx <- strwidth("xx") + sapply( labels, strwidth )
+	wy <- strheight("\n") + sapply( labels, strheight )
 	asp <- par("pin")[1]/diff(par("usr")[1:2]) /
 		(par("pin")[2]/diff(par("usr")[3:4]))
 	ex <- edges(x)

--- a/r/R/dagitty.r
+++ b/r/R/dagitty.r
@@ -1104,16 +1104,23 @@ plot.dagitty <- function( x,
 	}
 	if(!is.null(nodenames)){
 	  names(labels) <- names(coords$x)
+	  if(is.null(names(nodenames)))
+	    stop("'nodenames' must be named")
+	  if(!all(names(nodenames) %in% names(labels)))
+	    stop("node(s) not found: ", 
+	         paste0("'", setdiff(names(nodenames), names(labels)), "'", 
+	               collapse = ","))
 	  labels[names(nodenames)] <- nodenames
+	  names(labels) <- names(coords$x) # If coerced to expression, names are lost
 	}
 	omar <- par("mar")
 	par(mar=rep(0,4))
 	plot.new()
 	par(new=TRUE)
-	wx <- strwidth("mm",units="inches") + sapply( labels, 
-		function(s) strwidth(s,units="inches") )
-	wy <- strheight("\n") + sapply( labels, 
-		function(s) strheight(s,units="inches") )
+	wx <- sapply( labels, 
+	              function(s) strwidth(s,units="inches") ) + strwidth("mm",units="inches")
+	wy <- sapply( labels, 
+	              function(s) strheight(s,units="inches") ) + strheight("\n")
 	ppi.x <- dev.size("in")[1] / (max(coords$x)-min(coords$x))
 	ppi.y <- dev.size("in")[2] / (max(coords$y)-min(coords$y))
 	wx <- wx/ppi.x
@@ -1123,9 +1130,7 @@ plot.dagitty <- function( x,
 	plot( NA, xlim=xlim, ylim=ylim, xlab="", ylab="", bty="n",
 		xaxt="n", yaxt="n" )
 	wx <- sapply( labels, strwidth ) + strwidth("xx") 
-	names(wx) <- names(coords$x)
 	wy <- sapply( labels, strheight ) + strheight("\n")
-	names(wy) <- names(coords$x)
 	asp <- par("pin")[1]/diff(par("usr")[1:2]) /
 		(par("pin")[2]/diff(par("usr")[3:4]))
 	ex <- edges(x)

--- a/r/man/plot.dagitty.Rd
+++ b/r/man/plot.dagitty.Rd
@@ -4,8 +4,13 @@
 \alias{plot.dagitty}
 \title{Plot Graph}
 \usage{
-\method{plot}{dagitty}(x, abbreviate.names = FALSE,
-  show.coefficients = FALSE, ...)
+\method{plot}{dagitty}(
+  x,
+  abbreviate.names = FALSE,
+  show.coefficients = FALSE,
+  nodenames = NULL,
+  ...
+)
 }
 \arguments{
 \item{x}{the input graph, a DAG, MAG, or PDAG.}
@@ -15,10 +20,18 @@
 \item{show.coefficients}{logical. Whether to plot coefficients defined in the graph syntax
 on the edges.}
 
+\item{nodenames}{If not NULL, a named vector or expression list 
+to rename the nodes.}
+
 \item{...}{not used.}
 }
 \description{
 A simple plot method to quickly visualize a graph. This is intended mainly for 
 simple visualization purposes and not as a full-fledged graph drawing
 function.
+}
+\details{
+If \code{nodenames} is not \code{NULL}, it should be a 
+ named vector of characters or expressions to use to rename (some of) 
+ the nodes, e.g. node \code{"X"} could be renamed using \code{expression(X = alpha^2)}.
 }


### PR DESCRIPTION
`plot.dagitty` assumes nodes are labelled with text, but R graphics supports using expressions for labels with the plotmath scheme.  This adds a parameter to `plot.dagitty` called `nodenames`, that allows some or all of the nodes to be renamed.  For example, this code

```
library(dagitty)
g = dagitty('dag{
A [pos="-1,0.5"]
W [pos="0.893,-0.422"]
X [pos="0,-0.5"]
Y [pos="1,0.5"]
A -> Y
X -> A
X -> W
X -> Y
}')
plot(g, nodenames = expression(X = alpha^2))
```
plots the graph with node `X` labeled using `alpha^2`.