### PR TITLE
Propose to mention `jupyterlab-dagitty`

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -212,6 +212,7 @@ Conditional Instruments for Causal Inference.</a><br />
 		<li><a href="http://www.phil.cmu.edu/projects/tetrad/">TETRAD</a></li>
 		<li><a href="http://epi.dife.de/dag/">DAG program</a> </li>
 		<li><a href="http://journals.lww.com/epidem/Fulltext/2010/07000/dagR__A_Suite_of_R_Functions_for_Directed_Acyclic.26.aspx">dagR</a> </li>
+		<li><a href="https://github.com/krassowski/jupyterlab-dagitty">A JupyterLab extension to render dagitty models</a> </li>
 	  </ul>
 	  
 	  <p>Please contact me if you know of other programs that should be added to this list,


### PR DESCRIPTION
Hi, thanks again for `dagitty`. I had quite a few different models as text files, some for didactic and some for research purposes, and instead of storing them on the server I wanted to display the model in my IDE (JupyterLab), so I created this little JupyterLab extension: [`jupyterlab-dagitty`](https://github.com/krassowski/jupyterlab-dagitty) which itself depends on `dagitty` javascript code. You can try it online here: https://mybinder.org/v2/gh/krassowski/jupyterlab-dagitty/main?urlpath=lab/tree/examples/car_model_driver.dag


For now it is just a simple renderer, but I would like to expand its scope to add basic edit functions (adding/removing edges/nodes, changing node type) and add a button "Open in dagitty.net" (but I could not figure out a way to so so yet - I guess it would require the website to accept POST requests with model code as an argument?).

I'm curious what you think and whether you have any suggestions. Thanks again!