### PR TITLE
Use offsetX/Y to allow embedding in scrollable elements and improve performance

### DIFF
--- a/gui/js/dagitty.js
+++ b/gui/js/dagitty.js
@@ -7802,24 +7802,6 @@ var DAGittyGraphView = Class.extend({
 		this.registerEventListeners( obj?obj.autofocus:false )
 	},
 
-	pointerX : function(e) {
-		var docElement = document.documentElement,
-			body = document.body || { scrollLeft: 0 }
-
-		return e.pageX || (e.clientX +
-			(docElement.scrollLeft || body.scrollLeft) -
-			(docElement.clientLeft || 0))
-	},
-
-	pointerY : function(e) {
-		var docElement = document.documentElement,
-			body = document.body || { scrollTop: 0 }
-
-		return  e.pageY || (e.clientY +
-			(docElement.scrollTop || body.scrollTop) -
-			(docElement.clientTop || 0))
-	},
-
 	setStyle : function( sheetname ){
 		this.impl && this.impl.setStyle( sheetname )
 	},
@@ -7888,8 +7870,8 @@ var DAGittyGraphView = Class.extend({
 	clickHandler : function(e){
 		// click handler can be set to emulate keypress action
 		// using this function
-		this.last_click_x = this.pointerX(e)-this.getContainer().offsetLeft
-		this.last_click_y = this.pointerY(e)-this.getContainer().offsetTop
+		this.last_click_x = e.offsetX
+		this.last_click_y = e.offsetY
 		this.last_click_g_coords = this.toGraphCoordinate( this.last_click_x, this.last_click_y )
 		this.newVertexDialog() 
 	},
@@ -9079,8 +9061,8 @@ var GraphGUI_SVG = Class.extend({
 	},
 	touchVertexShape : function( el, e, bidi ){
 		this.last_touched_element = {"vertex" : el, "last_touch" : e.identifier}
-		this.start_x = this.pointerX(e)-this.getContainer().offsetLeft
-		this.start_y = this.pointerY(e)-this.getContainer().offsetTop
+		this.start_x = e.offsetX
+		this.start_y = e.offsetY
 		var pel = this.getMarkedVertexShape()
 		if( pel ){
 			this.unmarkVertexShape()
@@ -9096,8 +9078,8 @@ var GraphGUI_SVG = Class.extend({
 	},
 	touchEdgeShape : function( el, e ){
 		this.last_touched_element = {"edge" : el, "last_touch" : e.identifier}
-		this.start_x = this.pointerX(e)-this.getContainer().offsetLeft
-		this.start_y = this.pointerY(e)-this.getContainer().offsetTop
+		this.start_x = e.offsetX
+		this.start_y = e.offsetY
 		this.cancel_next_click = true
 		this.unmarkVertexShape()
 	},
@@ -9270,8 +9252,8 @@ var GraphGUI_SVG = Class.extend({
 			return
 		}
 
-		var ptr_x = this.pointerX(e)-this.getContainer().offsetLeft
-		var ptr_y = this.pointerY(e)-this.getContainer().offsetTop
+		var ptr_x = e.offsetX
+		var ptr_y = e.offsetY
 		
 		if(Math.abs(this.start_x - ptr_x) + 
 			Math.abs(this.start_y - ptr_y) > 30 ){
@@ -9337,24 +9319,5 @@ var GraphGUI_SVG = Class.extend({
 		svg.style.height = h+"px"
 		svg.setAttribute("width", w)
 		svg.setAttribute("height", w)
-	},
-
-
-	pointerX : function(e) {
-		var docElement = document.documentElement,
-			body = document.body || { scrollLeft: 0 }
-
-		return e.pageX || (e.clientX +
-			(docElement.scrollLeft || body.scrollLeft) -
-			(docElement.clientLeft || 0))
-	},
-
-	pointerY : function(e) {
-		var docElement = document.documentElement,
-			body = document.body || { scrollTop: 0 }
-
-		return  e.pageY || (e.clientY +
-			(docElement.scrollTop || body.scrollTop) -
-			(docElement.clientTop || 0))
 	}
 })

--- a/jslib/gui/GraphGUI_SVG.js
+++ b/jslib/gui/GraphGUI_SVG.js
@@ -273,8 +273,8 @@ var GraphGUI_SVG = Class.extend({
 	},
 	touchVertexShape : function( el, e, bidi ){
 		this.last_touched_element = {"vertex" : el, "last_touch" : e.identifier}
-		this.start_x = this.pointerX(e)-this.getContainer().offsetLeft
-		this.start_y = this.pointerY(e)-this.getContainer().offsetTop
+		this.start_x = e.offsetX
+		this.start_y = e.offsetY
 		var pel = this.getMarkedVertexShape()
 		if( pel ){
 			this.unmarkVertexShape()
@@ -290,8 +290,8 @@ var GraphGUI_SVG = Class.extend({
 	},
 	touchEdgeShape : function( el, e ){
 		this.last_touched_element = {"edge" : el, "last_touch" : e.identifier}
-		this.start_x = this.pointerX(e)-this.getContainer().offsetLeft
-		this.start_y = this.pointerY(e)-this.getContainer().offsetTop
+		this.start_x = e.offsetX
+		this.start_y = e.offsetY
 		this.cancel_next_click = true
 		this.unmarkVertexShape()
 	},
@@ -464,8 +464,8 @@ var GraphGUI_SVG = Class.extend({
 			return
 		}
 
-		var ptr_x = this.pointerX(e)-this.getContainer().offsetLeft
-		var ptr_y = this.pointerY(e)-this.getContainer().offsetTop
+		var ptr_x = e.offsetX
+		var ptr_y = e.offsetY
 		
 		if(Math.abs(this.start_x - ptr_x) + 
 			Math.abs(this.start_y - ptr_y) > 30 ){
@@ -531,24 +531,5 @@ var GraphGUI_SVG = Class.extend({
 		svg.style.height = h+"px"
 		svg.setAttribute("width", w)
 		svg.setAttribute("height", w)
-	},
-
-
-	pointerX : function(e) {
-		var docElement = document.documentElement,
-			body = document.body || { scrollLeft: 0 }
-
-		return e.pageX || (e.clientX +
-			(docElement.scrollLeft || body.scrollLeft) -
-			(docElement.clientLeft || 0))
-	},
-
-	pointerY : function(e) {
-		var docElement = document.documentElement,
-			body = document.body || { scrollTop: 0 }
-
-		return  e.pageY || (e.clientY +
-			(docElement.scrollTop || body.scrollTop) -
-			(docElement.clientTop || 0))
 	}
 })

--- a/jslib/gui/GraphGUI_View.js
+++ b/jslib/gui/GraphGUI_View.js
@@ -94,24 +94,6 @@ var DAGittyGraphView = Class.extend({
 		this.registerEventListeners( obj?obj.autofocus:false )
 	},
 
-	pointerX : function(e) {
-		var docElement = document.documentElement,
-			body = document.body || { scrollLeft: 0 }
-
-		return e.pageX || (e.clientX +
-			(docElement.scrollLeft || body.scrollLeft) -
-			(docElement.clientLeft || 0))
-	},
-
-	pointerY : function(e) {
-		var docElement = document.documentElement,
-			body = document.body || { scrollTop: 0 }
-
-		return  e.pageY || (e.clientY +
-			(docElement.scrollTop || body.scrollTop) -
-			(docElement.clientTop || 0))
-	},
-
 	setStyle : function( sheetname ){
 		this.impl && this.impl.setStyle( sheetname )
 	},
@@ -180,8 +162,8 @@ var DAGittyGraphView = Class.extend({
 	clickHandler : function(e){
 		// click handler can be set to emulate keypress action
 		// using this function
-		this.last_click_x = this.pointerX(e)-this.getContainer().offsetLeft
-		this.last_click_y = this.pointerY(e)-this.getContainer().offsetTop
+		this.last_click_x = e.offsetX
+		this.last_click_y = e.offsetY
 		this.last_click_g_coords = this.toGraphCoordinate( this.last_click_x, this.last_click_y )
 		this.newVertexDialog() 
 	},


### PR DESCRIPTION
`offsetX` and `offsetY` give directly the offset which so far was calculated in a multi-step process; these properties of mouse event have a very good support in browsers (see https://caniuse.com/mdn-api_mouseevent_offsetx - 97% coverage).

By delegating this to the browser, you get a better performance and correctness (previous code was not working when dagitty is placed inside an absolutely positioned or scrollable element).