### PR TITLE
Use CDN for underscore.js library

### DIFF
--- a/r/R/internal.R
+++ b/r/R/internal.R
@@ -80,7 +80,7 @@
 	if( !exists("ct",.dagitty.cache) ){
 		requireNamespace("V8",quietly=TRUE)
 		ct <- V8::new_context()
-		ct$source(system.file("js/underscore.js",package="V8"))
+		ct$source("https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.13.6/underscore-min.js")
 		ct$source(system.file("js/dagitty-alg.js",package="dagitty"))
 		ct$source(system.file("js/RUtil.js",package="dagitty"))
 		ct$source(system.file("js/example-dags.js",package="dagitty"))


### PR DESCRIPTION
Hi! We plan to remove the bundled `underscore.js` library from the V8 package. Can you update dagitty to use this library from another source?