### PR TITLE
use `writeLines()` to print empty adjustment sets to match other sets

### DIFF
--- a/r/R/dagitty.R
+++ b/r/R/dagitty.R
@@ -2163,7 +2163,7 @@ print.dagitty.ivs <- function( x, prefix="", ... ){
 print.dagitty.sets <- function( x, prefix="", ... ){
 	for( i in x ){
 		if( length(i) == 0 ){
-		  writeLines("{}")
+      writeLines("{}")
 		} else {
 			l <- paste("{ ",paste(i,collapse=", ")," }\n")
 			writeLines( strwrap( l, exdent=2 ) )

--- a/r/R/dagitty.R
+++ b/r/R/dagitty.R
@@ -2163,7 +2163,7 @@ print.dagitty.ivs <- function( x, prefix="", ... ){
 print.dagitty.sets <- function( x, prefix="", ... ){
 	for( i in x ){
 		if( length(i) == 0 ){
-      writeLines("{}")
+			writeLines("{}")
 		} else {
 			l <- paste("{ ",paste(i,collapse=", ")," }\n")
 			writeLines( strwrap( l, exdent=2 ) )

--- a/r/R/dagitty.R
+++ b/r/R/dagitty.R
@@ -2163,7 +2163,7 @@ print.dagitty.ivs <- function( x, prefix="", ... ){
 print.dagitty.sets <- function( x, prefix="", ... ){
 	for( i in x ){
 		if( length(i) == 0 ){
-			cat( prefix, "{}\n")
+		  writeLines("{}")
 		} else {
 			l <- paste("{ ",paste(i,collapse=", ")," }\n")
 			writeLines( strwrap( l, exdent=2 ) )


### PR DESCRIPTION
When printing an adjustment set where one of the sets is empty, there is a visual inconsistency in the empty set vs the others. The empty set is off to the right by a few characters. 

``` r
library(dagitty)
dagitty("x -> y; z -> y") |>
  adjustmentSets(exposure = "x", outcome = "y", type = "all")
#>  {}
#> { z }
```

<sup>Created on 2024-06-18 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>

This PR uses `writeLines()` instead of `cat()` to match the output of other sets.